### PR TITLE
[#54] Add registration method variant for Fragment without `ActivityResultRegistry`

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,7 @@
         <activity android:name=".ui.composePermission.ComposePermissionActivity"/>
         <activity android:name=".ui.multipermission.MultiPermissionActivity"/>
         <activity android:name=".ui.contacts.ContactsActivity"/>
+        <activity android:name=".ui.fragment.ExampleFragmentActivity"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/dev/shreyaspatil/permissionFlow/example/ui/MainActivity.kt
+++ b/app/src/main/java/dev/shreyaspatil/permissionFlow/example/ui/MainActivity.kt
@@ -22,6 +22,7 @@ import androidx.appcompat.app.AppCompatActivity
 import dev.shreyaspatil.permissionFlow.example.databinding.ActivityMainBinding
 import dev.shreyaspatil.permissionFlow.example.ui.composePermission.ComposePermissionActivity
 import dev.shreyaspatil.permissionFlow.example.ui.contacts.ContactsActivity
+import dev.shreyaspatil.permissionFlow.example.ui.fragment.ExampleFragmentActivity
 import dev.shreyaspatil.permissionFlow.example.ui.multipermission.MultiPermissionActivity
 
 class MainActivity : AppCompatActivity() {
@@ -36,6 +37,7 @@ class MainActivity : AppCompatActivity() {
             buttonContacts.setOnClickListener { launchScreen<ContactsActivity>() }
             buttonMultiPermission.setOnClickListener { launchScreen<MultiPermissionActivity>() }
             buttonComposeSample.setOnClickListener { launchScreen<ComposePermissionActivity>() }
+            buttonFragmentSample.setOnClickListener { launchScreen<ExampleFragmentActivity>() }
         }
     }
 

--- a/app/src/main/java/dev/shreyaspatil/permissionFlow/example/ui/fragment/ExampleFragment.kt
+++ b/app/src/main/java/dev/shreyaspatil/permissionFlow/example/ui/fragment/ExampleFragment.kt
@@ -1,0 +1,71 @@
+package dev.shreyaspatil.permissionFlow.example.ui.fragment
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.isVisible
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import dev.shreyaspatil.permissionFlow.PermissionFlow
+import dev.shreyaspatil.permissionFlow.example.databinding.ViewFragmentExampleBinding
+import dev.shreyaspatil.permissionFlow.utils.registerForPermissionFlowRequestsResult
+import kotlinx.coroutines.launch
+
+class ExampleFragment : Fragment() {
+
+    private var _binding: ViewFragmentExampleBinding? = null
+    private val binding: ViewFragmentExampleBinding get() = _binding!!
+
+    private val permissions = arrayOf(
+        android.Manifest.permission.CAMERA,
+        android.Manifest.permission.READ_CALL_LOG,
+        android.Manifest.permission.READ_CONTACTS,
+        android.Manifest.permission.READ_PHONE_STATE,
+    )
+
+    private val permissionFlow = PermissionFlow.getInstance()
+
+    private val permissionLauncher = registerForPermissionFlowRequestsResult()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = ViewFragmentExampleBinding.inflate(inflater, null, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initView()
+        observePermissions()
+    }
+
+    private fun initView() {
+        binding.button.setOnClickListener {
+            permissionLauncher.launch(permissions)
+        }
+    }
+
+    private fun observePermissions() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            permissionFlow.getMultiplePermissionState(*permissions).collect {
+                val grantedPermissionsText = it.grantedPermissions.joinToString(
+                    separator = "\n",
+                    prefix = "Granted Permissions:\n"
+                )
+                val deniedPermissionsText = it.deniedPermissions.joinToString(
+                    separator = "\n",
+                    prefix = "Denied Permissions:\n"
+                )
+
+                binding.grantedPermissionsText.text = grantedPermissionsText
+                binding.deniedPermissionsText.text = deniedPermissionsText
+
+                binding.button.isVisible = !it.allGranted
+            }
+        }
+    }
+}

--- a/app/src/main/java/dev/shreyaspatil/permissionFlow/example/ui/fragment/ExampleFragment.kt
+++ b/app/src/main/java/dev/shreyaspatil/permissionFlow/example/ui/fragment/ExampleFragment.kt
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2022 Shreyas Patil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package dev.shreyaspatil.permissionFlow.example.ui.fragment
 
 import android.os.Bundle
@@ -31,7 +46,7 @@ class ExampleFragment : Fragment() {
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
-        savedInstanceState: Bundle?
+        savedInstanceState: Bundle?,
     ): View {
         _binding = ViewFragmentExampleBinding.inflate(inflater, null, false)
         return binding.root
@@ -54,11 +69,11 @@ class ExampleFragment : Fragment() {
             permissionFlow.getMultiplePermissionState(*permissions).collect {
                 val grantedPermissionsText = it.grantedPermissions.joinToString(
                     separator = "\n",
-                    prefix = "Granted Permissions:\n"
+                    prefix = "Granted Permissions:\n",
                 )
                 val deniedPermissionsText = it.deniedPermissions.joinToString(
                     separator = "\n",
-                    prefix = "Denied Permissions:\n"
+                    prefix = "Denied Permissions:\n",
                 )
 
                 binding.grantedPermissionsText.text = grantedPermissionsText

--- a/app/src/main/java/dev/shreyaspatil/permissionFlow/example/ui/fragment/ExampleFragmentActivity.kt
+++ b/app/src/main/java/dev/shreyaspatil/permissionFlow/example/ui/fragment/ExampleFragmentActivity.kt
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2022 Shreyas Patil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package dev.shreyaspatil.permissionFlow.example.ui.fragment
 
 import android.os.Bundle

--- a/app/src/main/java/dev/shreyaspatil/permissionFlow/example/ui/fragment/ExampleFragmentActivity.kt
+++ b/app/src/main/java/dev/shreyaspatil/permissionFlow/example/ui/fragment/ExampleFragmentActivity.kt
@@ -1,0 +1,19 @@
+package dev.shreyaspatil.permissionFlow.example.ui.fragment
+
+import android.os.Bundle
+import android.widget.FrameLayout
+import androidx.appcompat.app.AppCompatActivity
+import dev.shreyaspatil.permissionFlow.example.R
+
+class ExampleFragmentActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_fragment_example)
+        findViewById<FrameLayout>(R.id.frameLayout).let { frameLayout ->
+            supportFragmentManager
+                .beginTransaction()
+                .replace(frameLayout.id, ExampleFragment())
+                .commit()
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_fragment_example.xml
+++ b/app/src/main/res/layout/activity_fragment_example.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <FrameLayout
+        android:id="@+id/frameLayout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -26,4 +26,11 @@
         android:layout_height="wrap_content"
         android:text="Observing permissions in Compose"
         tools:ignore="HardcodedText" />
+
+    <Button
+        android:id="@+id/buttonFragmentSample"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Fragment Example"
+        tools:ignore="HardcodedText" />
 </LinearLayout>

--- a/app/src/main/res/layout/view_fragment_example.xml
+++ b/app/src/main/res/layout/view_fragment_example.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp">
+
+    <Button
+        android:id="@+id/button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:text="Request Permissions"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/grantedPermissionsText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:text="Granted Permissions:"
+        android:textColor="#009688"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/button" />
+
+    <TextView
+        android:id="@+id/deniedPermissionsText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:text="Denied Permissions:"
+        android:textColor="#E91E63"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/grantedPermissionsText" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ RELEASE_SIGNING_ENABLED=true
 SONATYPE_AUTOMATIC_RELEASE=true
 
 GROUP=dev.shreyaspatil.permission-flow
-VERSION_NAME=1.0.0-rc01
+VERSION_NAME=1.1.1
 
 POM_INCEPTION_YEAR=2022
 POM_URL=https://github.com/PatilShreyas/permission-flow-android/

--- a/permission-flow/src/main/java/dev/shreyaspatil/permissionFlow/utils/PermissionResultLauncher.kt
+++ b/permission-flow/src/main/java/dev/shreyaspatil/permissionFlow/utils/PermissionResultLauncher.kt
@@ -74,6 +74,35 @@ fun ComponentActivity.registerForPermissionFlowRequestsResult(
  * ```
  *
  * @param requestPermissionsContract A contract specifying permission request and result.
+ * registry.
+ * @param callback Callback of a permission state change.
+ */
+@JvmOverloads
+fun Fragment.registerForPermissionFlowRequestsResult(
+    requestPermissionsContract: RequestPermissionsContract = RequestPermissionsContract(),
+    callback: ActivityResultCallback<Map<String, Boolean>> = emptyCallback(),
+): ActivityResultLauncher<Array<String>> = registerForActivityResult(
+    requestPermissionsContract,
+    callback,
+)
+
+/**
+ * Returns a [ActivityResultLauncher] for this Fragment which internally notifies [PermissionFlow]
+ * about the state change whenever permission state is changed with this launcher.
+ *
+ * Usage:
+ *
+ * ```
+ *  class MyFragment: Fragment() {
+ *      private val permissionLauncher = registerForPermissionFlowRequestsResult()
+ *
+ *      fun askContactPermission() {
+ *          permissionLauncher.launch(android.Manifest.permission.READ_CONTACTS)
+ *      }
+ *  }
+ * ```
+ *
+ * @param requestPermissionsContract A contract specifying permission request and result.
  * @param activityResultRegistry Activity result registry. By default it uses Activity's Result
  * registry.
  * @param callback Callback of a permission state change.
@@ -81,7 +110,7 @@ fun ComponentActivity.registerForPermissionFlowRequestsResult(
 @JvmOverloads
 fun Fragment.registerForPermissionFlowRequestsResult(
     requestPermissionsContract: RequestPermissionsContract = RequestPermissionsContract(),
-    activityResultRegistry: ActivityResultRegistry = requireActivity().activityResultRegistry,
+    activityResultRegistry: ActivityResultRegistry,
     callback: ActivityResultCallback<Map<String, Boolean>> = emptyCallback(),
 ): ActivityResultLauncher<Array<String>> = registerForActivityResult(
     requestPermissionsContract,


### PR DESCRIPTION
# Summary

Added a new method for registering permission result launcher for Fragment without parameter of `ActivityResultRegistry`.

Fixes: #54 